### PR TITLE
[SG] feat: 시큐리티 그룹 모듈 추가

### DIFF
--- a/terraform/modules/security-group/main.tf
+++ b/terraform/modules/security-group/main.tf
@@ -1,0 +1,34 @@
+resource "aws_security_group" "this" {
+  name        = "${var.name_prefix}-${var.sg_name}"
+  description = var.description
+  vpc_id      = var.vpc_id
+
+  dynamic "ingress" {
+    for_each = var.ingress_rules
+    content {
+      from_port   = ingress.value.from_port
+      to_port     = ingress.value.to_port
+      protocol    = ingress.value.protocol
+      cidr_blocks = lookup(ingress.value, "cidr_blocks", [])
+      security_groups = lookup(ingress.value, "security_groups", [])
+      description = lookup(ingress.value, "description", null)
+    }
+  }
+
+  dynamic "egress" {
+    for_each = var.egress_rules
+    content {
+      from_port   = egress.value.from_port
+      to_port     = egress.value.to_port
+      protocol    = egress.value.protocol
+      cidr_blocks = lookup(egress.value, "cidr_blocks", [])
+      security_groups = lookup(egress.value, "security_groups", [])
+      description = lookup(egress.value, "description", null)
+    }
+  }
+
+  tags = {
+    Name        = "${var.name_prefix}-${var.sg_name}"
+    Environment = var.environment
+  }
+}

--- a/terraform/modules/security-group/main.tf
+++ b/terraform/modules/security-group/main.tf
@@ -6,24 +6,24 @@ resource "aws_security_group" "this" {
   dynamic "ingress" {
     for_each = var.ingress_rules
     content {
-      from_port   = ingress.value.from_port
-      to_port     = ingress.value.to_port
-      protocol    = ingress.value.protocol
-      cidr_blocks = lookup(ingress.value, "cidr_blocks", [])
+      from_port       = ingress.value.from_port
+      to_port         = ingress.value.to_port
+      protocol        = ingress.value.protocol
+      cidr_blocks     = lookup(ingress.value, "cidr_blocks", [])
       security_groups = lookup(ingress.value, "security_groups", [])
-      description = lookup(ingress.value, "description", null)
+      description     = lookup(ingress.value, "description", null)
     }
   }
 
   dynamic "egress" {
     for_each = var.egress_rules
     content {
-      from_port   = egress.value.from_port
-      to_port     = egress.value.to_port
-      protocol    = egress.value.protocol
-      cidr_blocks = lookup(egress.value, "cidr_blocks", [])
+      from_port       = egress.value.from_port
+      to_port         = egress.value.to_port
+      protocol        = egress.value.protocol
+      cidr_blocks     = lookup(egress.value, "cidr_blocks", [])
       security_groups = lookup(egress.value, "security_groups", [])
-      description = lookup(egress.value, "description", null)
+      description     = lookup(egress.value, "description", null)
     }
   }
 

--- a/terraform/modules/security-group/outputs.tf
+++ b/terraform/modules/security-group/outputs.tf
@@ -1,0 +1,3 @@
+output "security_group_id" {
+  value = aws_security_group.this.id
+}

--- a/terraform/modules/security-group/variables.tf
+++ b/terraform/modules/security-group/variables.tf
@@ -1,0 +1,48 @@
+variable "name_prefix" {
+  type        = string
+  description = "리소스 이름 접두사"
+}
+
+variable "sg_name" {
+  type        = string
+  description = "보안 그룹 이름"
+}
+
+variable "description" {
+  type        = string
+  description = "보안 그룹 설명"
+}
+
+variable "vpc_id" {
+  type        = string
+  description = "VPC ID"
+}
+
+variable "environment" {
+  type        = string
+  description = "환경명 (dev, prod 등)"
+}
+
+variable "ingress_rules" {
+  type = list(object({
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+    description     = optional(string)
+  }))
+  default = []
+}
+
+variable "egress_rules" {
+  type = list(object({
+    from_port       = number
+    to_port         = number
+    protocol        = string
+    cidr_blocks     = optional(list(string))
+    security_groups = optional(list(string))
+    description     = optional(string)
+  }))
+  default = []
+}


### PR DESCRIPTION
## 📌 PR 제목
[SG] feat: 시큐리티 그룹 모듈 추가

## ✅ 작업 내용
- 시큐리티 그룹 모듈

## 🔧 변경 사항
- 시큐리티 그룹 모듈 추가 및 폴더 생성 

## 📎 관련 이슈
- 관련 이슈 번호: #7 

## 📋 참고 사항
- 루트모듈에서 EKS, RDS 등 보안그룹 설정은 나중에 적용 또는 각자 적용
- 예시
```hcl
module "alb_sg" {
  source      = "./modules/security-group"
  name_prefix = var.team_name
  sg_name     = "alb"
  description = "ALB access"
  vpc_id      = module.vpc.vpc_id
  environment = "dev"

  ingress_rules = [
    {
      from_port   = 80
      to_port     = 80
      protocol    = "tcp"
      cidr_blocks = ["0.0.0.0/0"]
      description = "Allow HTTP"
    },
    {
      from_port   = 443
      to_port     = 443
      protocol    = "tcp"
      cidr_blocks = ["0.0.0.0/0"]
      description = "Allow HTTPS"
    }
  ]

  egress_rules = [
    {
      from_port   = 0
      to_port     = 0
      protocol    = "-1"
      cidr_blocks = ["0.0.0.0/0"]
      description = "Allow all outbound"
    }
  ]
}

``` 
