### PR TITLE
fix(subnet): Private subnet의 app 및 data 구분

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -4,7 +4,7 @@ provider "aws" {
 
 # EKS 클러스터 IAM 역할
 resource "aws_iam_role" "eks_cluster_role" {
-  name = "${var.team_name}-eks-cluster-role" 
+  name = "${var.team_name}-eks-cluster-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -126,7 +126,7 @@ module "elasticache" {
   name_prefix = "${var.team_name}-ng"
   environment = "dev"
   vpc_id      = module.vpc.vpc_id
-  subnet_ids  = module.subnet.private_subnet_ids
+  subnet_ids  = module.subnet.private_subnet_ids_data
   # allowed_sg_ids = [ module.eks.workernode_sg_id ] eks 워커노드 sg
   allowed_sg_ids     = [""]
   engine_version     = "7.1"
@@ -142,8 +142,8 @@ module "eks" {
   environment = "dev"
   # EKS 클러스터가 사용할 IAM 역할 ARN을 지정해야 합니다.
   # 예: aws_iam_role.eks_cluster_role.arn
-  cluster_iam_role_arn = aws_iam_role.eks_cluster_role.arn # EKS 클러스터 IAM 역할 ARN 연결
-  subnet_ids           = module.subnet.private_subnet_ids  # EKS 클러스터는 Private Subnet에 배포
+  cluster_iam_role_arn = aws_iam_role.eks_cluster_role.arn    # EKS 클러스터 IAM 역할 ARN 연결
+  subnet_ids           = module.subnet.private_subnet_ids_app # EKS 클러스터는 Private Subnet에 배포
   # cluster_security_group_ids = [aws_security_group.eks_cluster_sg.id] # 필요시 EKS 클러스터 보안 그룹 지정
 }
 
@@ -155,6 +155,6 @@ module "eks_node_group" {
   cluster_name = module.eks.cluster_name
   # EKS 노드 그룹이 사용할 IAM 역할 ARN을 지정해야 합니다.
   # 예: aws_iam_role.eks_node_role.arn
-  node_role_arn = aws_iam_role.eks_node_role.arn   # EKS 노드 그룹 IAM 역할 ARN 연결
-  subnet_ids    = module.subnet.private_subnet_ids # 노드 그룹은 Private Subnet에 배포
+  node_role_arn = aws_iam_role.eks_node_role.arn       # EKS 노드 그룹 IAM 역할 ARN 연결
+  subnet_ids    = module.subnet.private_subnet_ids_app # 노드 그룹은 Private Subnet에 배포
 }

--- a/terraform/modules/network/subnet/main.tf
+++ b/terraform/modules/network/subnet/main.tf
@@ -22,5 +22,6 @@ resource "aws_subnet" "private" {
     Name        = "${var.name_prefix}-private-${count.index}"
     Environment = var.environment
     Tier        = "private"
+    type        = count.index < length(var.azs) ? "app" : "data"
   }
 }

--- a/terraform/modules/network/subnet/outputs.tf
+++ b/terraform/modules/network/subnet/outputs.tf
@@ -7,3 +7,13 @@ output "private_subnet_ids" {
   value       = aws_subnet.private[*].id
   description = "Private Subnet ID 리스트"
 }
+
+output "private_subnet_ids_app" {
+  value       = [for s in aws_subnet.private : s.id if s.tags["type"] == "app"]
+  description = "app private subnet"
+}
+
+output "private_subnet_ids_data" {
+  value       = [for s in aws_subnet.private : s.id if s.tags["type"] == "data"]
+  description = "data private subnet"
+}


### PR DESCRIPTION
## 📌 PR 제목
[Fix] Private subnet의 app 및 data 구분

## ✅ 작업 내용
- Subnet tag (app, data) 추가
- Subnet output (app, data) 추가
- EKS 및 ElastiCache에서 상기 추가된 subnet tag 참고하도록 수정

## 🔧 변경 사항
- 추가/수정된 기능 요약
1. Subnet tag (app, data) 추가
2. Subnet output (app, data) 추가
3. EKS 및 ElastiCache에서 상기 추가된 subnet tag 참고하도록 수정
- 변경된 주요 파일 폴더 
1. /terraform/network/subnet/main.tf
2. /terraform/network/subnet/outputs.tf
3. /terraform/main.tf

## 📎 관련 이슈
- 관련 이슈 번호: #12 

## 📋 참고 사항
- 리뷰 시 참고할 내용이나 추가 설명
