### PR TITLE
Feat/ec2

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -2,9 +2,8 @@ provider "aws" {
   region = "ap-northeast-2"
 }
 
-# EKS 클러스터 IAM 역할
 resource "aws_iam_role" "eks_cluster_role" {
-  name = "${var.team_name}-eks-cluster-role" 
+  name = "${var.team_name}-eks-cluster-role"
 
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
@@ -25,19 +24,16 @@ resource "aws_iam_role" "eks_cluster_role" {
   }
 }
 
-# EKS 클러스터 정책 연결
 resource "aws_iam_role_policy_attachment" "eks_cluster_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
   role       = aws_iam_role.eks_cluster_role.name
 }
 
-# EKS 서비스 정책 연결
 resource "aws_iam_role_policy_attachment" "eks_service_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
   role       = aws_iam_role.eks_cluster_role.name
 }
 
-# EKS 노드 그룹 IAM 역할
 resource "aws_iam_role" "eks_node_role" {
   name = "${var.team_name}-eks-node-role" # 팀 prefix를 사용한 역할 이름
 
@@ -60,19 +56,16 @@ resource "aws_iam_role" "eks_node_role" {
   }
 }
 
-# EKS 워커 노드 정책 연결
 resource "aws_iam_role_policy_attachment" "eks_worker_node_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
   role       = aws_iam_role.eks_node_role.name
 }
 
-# EKS CNI 정책 연결
 resource "aws_iam_role_policy_attachment" "eks_cni_policy" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
   role       = aws_iam_role.eks_node_role.name
 }
 
-# EC2 컨테이너 레지스트리 읽기 전용 정책 연결
 resource "aws_iam_role_policy_attachment" "ec2_container_registry_read_only" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
   role       = aws_iam_role.eks_node_role.name
@@ -135,7 +128,6 @@ module "elasticache" {
   number_of_replicas = 2
 }
 
-# EKS 클러스터 모듈
 module "eks" {
   source      = "./modules/eks"
   name_prefix = var.team_name
@@ -147,7 +139,6 @@ module "eks" {
   # cluster_security_group_ids = [aws_security_group.eks_cluster_sg.id] # 필요시 EKS 클러스터 보안 그룹 지정
 }
 
-# EKS 노드 그룹 모듈
 module "eks_node_group" {
   source       = "./modules/eks-node-group"
   name_prefix  = var.team_name
@@ -157,4 +148,50 @@ module "eks_node_group" {
   # 예: aws_iam_role.eks_node_role.arn
   node_role_arn = aws_iam_role.eks_node_role.arn   # EKS 노드 그룹 IAM 역할 ARN 연결
   subnet_ids    = module.subnet.private_subnet_ids # 노드 그룹은 Private Subnet에 배포
+}
+
+# EC2 인스턴스에 적용할 보안 그룹
+resource "aws_security_group" "ec2_sg" {
+  name        = "${var.team_name}-ec2-sg"
+  description = "Allow HTTP/SSH traffic to EC2"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 22
+    to_port     = 22
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = {
+    Name        = "${var.team_name}-ec2-sg"
+    Environment = var.environment
+  }
+}
+
+# EC2 인스턴스 모듈
+module "ec2" {
+  source             = "./modules/ec2"
+  name_prefix        = var.team_name
+  environment        = var.environment
+  ami_id             = var.ec2_ami_id
+  instance_type      = var.ec2_instance_type
+  subnet_id          = module.subnet.public_subnet_ids[0] # 퍼블릭 서브넷에 배포
+  security_group_ids = [aws_security_group.ec2_sg.id]
+  key_name           = var.ec2_key_name
+  tags               = {}
 }

--- a/terraform/modules/ec2/main.tf
+++ b/terraform/modules/ec2/main.tf
@@ -1,0 +1,15 @@
+resource "aws_instance" "this" {
+  ami                    = var.ami_id
+  instance_type          = var.instance_type
+  subnet_id              = var.subnet_id
+  vpc_security_group_ids = var.security_group_ids
+  key_name               = var.key_name
+
+  tags = merge(
+    {
+      Name        = "${var.name_prefix}-ec2-instance"
+      Environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/terraform/modules/ec2/outputs.tf
+++ b/terraform/modules/ec2/outputs.tf
@@ -1,0 +1,3 @@
+output "instance_id" {
+  value = aws_instance.this.id
+}

--- a/terraform/modules/ec2/variables.tf
+++ b/terraform/modules/ec2/variables.tf
@@ -1,0 +1,42 @@
+variable "name_prefix" {
+  description = "Prefix for resource names"
+  type        = string
+}
+
+variable "environment" {
+  description = "Environment for resources"
+  type        = string
+}
+
+variable "ami_id" {
+  description = "AMI for EC2 instance"
+  type        = string
+  default     = "ami-08943a151bd468f4e"
+}
+
+variable "instance_type" {
+  description = "Instance type for EC2"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "subnet_id" {
+  description = "Subnet ID for EC2 instance"
+  type        = string
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs for EC2 instance"
+  type        = list(string)
+}
+
+variable "key_name" {
+  description = "Key name for EC2 instance"
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/modules/eks/main.tf
+++ b/terraform/modules/eks/main.tf
@@ -1,4 +1,3 @@
-# EKS Cluster Resource
 resource "aws_eks_cluster" "this" {
   name     = "${var.name_prefix}-eks-cluster"
   version  = var.kubernetes_version

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,3 +1,4 @@
+
 variable "team_name" {
   description = "Name of team name"
   type        = string
@@ -8,4 +9,22 @@ variable "environment" {
   description = "환경 태그 (예: dev, staging, prod)"
   type        = string
   default     = "dev"
+}
+
+variable "ec2_ami_id" {
+  description = "EC2 인스턴스에 사용할 AMI ID"
+  type        = string
+  default     = "ami-08943a151bd468f4e" 
+}
+
+variable "ec2_instance_type" {
+  description = "EC2 인스턴스 유형"
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "ec2_key_name" {
+  description = "EC2 인스턴스에 사용할 키 페어 이름"
+  type        = string
+  default     = ""
 }


### PR DESCRIPTION
## 📌 PR 제목
[Feat]: EC2 인스턴스 생성 기능 추가
## ✅ 작업 내용
- AWS EC2 인스턴스 배포를 위한 Terraform 모듈 및 리소스 정의

## 🔧 변경 사항
- main.tf: EC2 인스턴스 생성을 위한 module "ec2" 블록 추가
- modules/ec2/ 생성

## 📎 관련 이슈
- 관련 이슈 번호: #123

## 📋 참고 사항
- EC2 인스턴스는 퍼블릭 서브넷에 배포되며, HTTP(80) 및 SSH(22) 포트가 모든 IP(0.0.0.0/0)에 대해 열려 있습니다.
