### PR TITLE
EKS 연결 관련 추가

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version = "6.2.0"
   hashes = [
     "h1:kdCz5arAOCkH/Onr+vhbOMuO0wa+q8GNQ3mrV3tMlbk=",
+    "h1:ziUjk3KGwBa7bAwZaPuQklfcQ3Qlx2d0rlYFvdZn4g8=",
     "zh:224b20371f7c7ce14d69a84e16ae94baa0a06c132474d4bc4d192d86936bc750",
     "zh:2c079ad275c32b9abae7616d07c24901340207a85995ce0025ac38af16b317b7",
     "zh:2d139c99d6e8e48cc5439c2945eee583bb3a2d7faf484639cdfd4590ebc294f2",

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -156,8 +156,8 @@ module "eks_node_group" {
   cluster_name = module.eks.cluster_name
   # EKS 노드 그룹이 사용할 IAM 역할 ARN을 지정해야 합니다.
   # 예: aws_iam_role.eks_node_role.arn
-  node_role_arn = aws_iam_role.eks_node_role.arn   # EKS 노드 그룹 IAM 역할 ARN 연결
-  subnet_ids    = module.subnet.private_subnet_ids # 노드 그룹은 Private Subnet에 배포
+  node_role_arn                           = aws_iam_role.eks_node_role.arn   # EKS 노드 그룹 IAM 역할 ARN 연결
+  subnet_ids                              = module.subnet.private_subnet_ids # 노드 그룹은 Private Subnet에 배포
   ssh_key_name                            = var.ec2_key_name
   remote_access_source_security_group_ids = [aws_security_group.ec2_sg.id]
 }
@@ -235,7 +235,7 @@ module "rds_sg" {
       from_port       = 3306
       to_port         = 3306
       protocol        = "tcp"
-      security_groups = [module.eks_node_sg.security_group_id] # EKS에서만 접근 허용
+      security_groups = [module.eks_node_sg.security_group_id, module.eks.cluster_security_group_id] # EKS 노드 + 클러스터 SG 허용
       description     = "Allow MySQL from EKS nodes"
     }
   ]
@@ -282,9 +282,9 @@ module "eks_node_sg" {
 }
 
 module "dynamodb" {
-  source         = "./modules/dynamodb"
-  name_prefix    = var.team_name
-  environment    = "dev"
-  hash_key       = "album_id"
-  hash_key_type  = "S"
+  source        = "./modules/dynamodb"
+  name_prefix   = var.team_name
+  environment   = "dev"
+  hash_key      = "album_id"
+  hash_key_type = "S"
 }

--- a/terraform/modules/eks-node-group/main.tf
+++ b/terraform/modules/eks-node-group/main.tf
@@ -20,4 +20,9 @@ resource "aws_eks_node_group" "this" {
   }
 
   # EKS 노드 그룹 생성 시 필요한 추가 설정 (예: AMI 타입, 원격 액세스 등)은 여기에 추가
+
+  remote_access {
+    ec2_ssh_key               = var.ssh_key_name
+    source_security_group_ids = var.remote_access_source_security_group_ids
+  }
 }

--- a/terraform/modules/eks-node-group/variables.tf
+++ b/terraform/modules/eks-node-group/variables.tf
@@ -48,3 +48,13 @@ variable "min_size" {
   type        = number
   default     = 1
 }
+
+variable "ssh_key_name" {
+  description = "ssh key pair name to connect node remote"
+  type        = string
+}
+
+variable "remote_access_source_security_group_ids" {
+  description = "sg id list to allow remote connection (bastion SG)"
+  type        = list(string)
+}

--- a/terraform/modules/eks/outputs.tf
+++ b/terraform/modules/eks/outputs.tf
@@ -22,3 +22,8 @@ output "cluster_name" {
   description = "생성된 EKS 클러스터의 이름"
   value       = aws_eks_cluster.this.name
 }
+
+output "cluster_security_group_id" {
+  description = "EKS sg id"
+  value       = aws_eks_cluster.this.vpc_config[0].cluster_security_group_id
+}

--- a/terraform/modules/elasticache/main.tf
+++ b/terraform/modules/elasticache/main.tf
@@ -4,12 +4,10 @@ resource "aws_security_group" "redis" {
   vpc_id      = var.vpc_id
 
   ingress {
-    from_port = var.port
-    to_port   = var.port
-    protocol  = "tcp"
-    # TODO: EKS 워커노드 sg로 변경 후 cidr block 삭제
-    # security_groups = var.allowed_sg_ids
-    cidr_blocks = ["0.0.0.0/0"]
+    from_port       = var.port
+    to_port         = var.port
+    protocol        = "tcp"
+    security_groups = var.allowed_sg_ids
   }
 
   egress {

--- a/terraform/modules/elasticache/main.tf
+++ b/terraform/modules/elasticache/main.tf
@@ -27,6 +27,10 @@ resource "aws_elasticache_subnet_group" "redis" {
   name        = "${var.name_prefix}-redis-subnet-group"
   description = "Redis subnet group"
   subnet_ids  = var.subnet_ids
+
+  lifecycle {
+    create_before_destroy = true
+  }
 }
 
 resource "aws_elasticache_replication_group" "redis" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -26,5 +26,5 @@ variable "ec2_instance_type" {
 variable "ec2_key_name" {
   description = "EC2 인스턴스에 사용할 키 페어 이름"
   type        = string
-  default     = ""
+  default     = "test"
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -14,7 +14,7 @@ variable "environment" {
 variable "ec2_ami_id" {
   description = "EC2 인스턴스에 사용할 AMI ID"
   type        = string
-  default     = "ami-08943a151bd468f4e" 
+  default     = "ami-08943a151bd468f4e"
 }
 
 variable "ec2_instance_type" {
@@ -26,7 +26,7 @@ variable "ec2_instance_type" {
 variable "ec2_key_name" {
   description = "EC2 인스턴스에 사용할 키 페어 이름"
   type        = string
-  default     = "test"
+  default     = ""
 }
 
 variable "rds_password" {


### PR DESCRIPTION
## 📌 PR 제목
EKS 연결 관련 추가

## ✅ 작업 내용
- EKS <-> RDS, ElastiCache, Bastion 연결 추가

## 🔧 변경 사항
- EKS, Bastion EC2 연결
- EKS, ElastiCache 연결 추가 (Via security group)
- EKS, RDS 연결 추가 (Via security group)
- ElastiCache와 RDS 둘 다 module.eks.cluster_security_group_id 참조로 연결
- 변경된 주요 파일 폴더 
1. EKS 모듈
2. ElastiCache 모듈
3. root의 main.tf 상 RDS 보안그룹 추가
4. root의 main.tf 상 EKS cluster sg에 bastion ec2 sg 추가(eks_api_from_bastion)

## 📋 참고 사항

**EKS-Bastion connection**
<img width="916" height="106" alt="image" src="https://github.com/user-attachments/assets/661fc16c-5aa3-4cb3-a02c-beb07fb48a47" />

**EKS-ElastiCache connection**
<img width="739" height="120" alt="image" src="https://github.com/user-attachments/assets/912011ae-39cf-4959-ac22-c8d078430848" />

**EKS-RDS connection**
<img width="1095" height="216" alt="image" src="https://github.com/user-attachments/assets/1b7c40e2-5a2c-4d3b-8fd7-e4356f574795" />
<img width="1096" height="109" alt="image" src="https://github.com/user-attachments/assets/e4069b5c-8602-4505-b459-696f9571152c" />
