### PR TITLE
feat: keypair 자동다운로드 , route53모듈 생성

### DIFF
--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -24,6 +24,25 @@ provider "registry.terraform.io/hashicorp/aws" {
   ]
 }
 
+provider "registry.terraform.io/hashicorp/local" {
+  version = "2.5.3"
+  hashes = [
+    "h1:xb77x0HwwHCexdX4nLf5SrknvPskapmi4i1Vk5Tni1M=",
+    "zh:284d4b5b572eacd456e605e94372f740f6de27b71b4e1fd49b63745d8ecd4927",
+    "zh:40d9dfc9c549e406b5aab73c023aa485633c1b6b730c933d7bcc2fa67fd1ae6e",
+    "zh:6243509bb208656eb9dc17d3c525c89acdd27f08def427a0dce22d5db90a4c8b",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:885d85869f927853b6fe330e235cd03c337ac3b933b0d9ae827ec32fa1fdcdbf",
+    "zh:bab66af51039bdfcccf85b25fe562cbba2f54f6b3812202f4873ade834ec201d",
+    "zh:c505ff1bf9442a889ac7dca3ac05a8ee6f852e0118dd9a61796a2f6ff4837f09",
+    "zh:d36c0b5770841ddb6eaf0499ba3de48e5d4fc99f4829b6ab66b0fab59b1aaf4f",
+    "zh:ddb6a407c7f3ec63efb4dad5f948b54f7f4434ee1a2607a49680d494b1776fe1",
+    "zh:e0dafdd4500bec23d3ff221e3a9b60621c5273e5df867bc59ef6b7e41f5c91f6",
+    "zh:ece8742fd2882a8fc9d6efd20e2590010d43db386b920b2a9c220cfecc18de47",
+    "zh:f4c6b3eb8f39105004cf720e202f04f57e3578441cfb76ca27611139bc116a82",
+  ]
+}
+
 provider "registry.terraform.io/hashicorp/tls" {
   version = "4.1.0"
   hashes = [

--- a/terraform/modules/iam_alb_controller/main.tf
+++ b/terraform/modules/iam_alb_controller/main.tf
@@ -1,10 +1,4 @@
-data "aws_eks_cluster" "cluster" {
-  name = var.cluster_name
-}
 
-data "aws_eks_cluster_auth" "cluster" {
-  name = var.cluster_name
-}
 
 data "aws_iam_policy_document" "assume_role" {
   statement {
@@ -23,6 +17,14 @@ data "aws_iam_policy_document" "assume_role" {
       values   = ["system:serviceaccount:kube-system:aws-load-balancer-controller"]
     }
   }
+}
+
+data "aws_eks_cluster" "cluster" {
+  name = var.cluster_name
+}
+
+data "aws_eks_cluster_auth" "cluster" {
+  name = var.cluster_name
 }
 
 resource "aws_iam_openid_connect_provider" "oidc" {

--- a/terraform/modules/route53/main.tf
+++ b/terraform/modules/route53/main.tf
@@ -1,0 +1,5 @@
+resource "aws_route53_zone" "main" {
+  name = var.domain_name
+
+  tags = var.tags
+}

--- a/terraform/modules/route53/outputs.tf
+++ b/terraform/modules/route53/outputs.tf
@@ -1,0 +1,9 @@
+output "zone_id" {
+  description = "The ID of the Route 53 Hosted Zone."
+  value       = aws_route53_zone.main.zone_id
+}
+
+output "name_servers" {
+  description = "The name servers for the Route 53 Hosted Zone."
+  value       = aws_route53_zone.main.name_servers
+}

--- a/terraform/modules/route53/variables.tf
+++ b/terraform/modules/route53/variables.tf
@@ -1,0 +1,10 @@
+variable "domain_name" {
+  description = "The domain name for the Route 53 hosted zone."
+  type        = string
+}
+
+variable "tags" {
+  description = "A map of tags to assign to the resource."
+  type        = map(string)
+  default     = {}
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -30,3 +30,8 @@ variable "rds_password" {
   description = "RDS 비밀번호"
   sensitive   = true
 }
+
+variable "domain_name" {
+  description = "The domain name to use for Route 53."
+  type        = string
+}


### PR DESCRIPTION
## 📌 PR 제목
[Feature]: keypair  download, route53

## ✅ 작업 내용
- route 53 모듈, kepair 자동 다운로드(terraform 디렉터리로) 

## 🔧 변경 사항
- modules\route53
- keypair 로인한 main.tf 

## 📎 관련 이슈
- 관련 이슈 번호: #123

## 📋 참고 사항
-명령어 안적어도 keypair 자동적으로 다운되도록 설정했습니다
-terraform.tfvars에  domain_name  = "r53.shop" 설정해주시고 제가  가비아에서 설정하면될거같습니다

